### PR TITLE
fix typo in openapi.pyi

### DIFF
--- a/python/pysrc/longbridge/openapi.pyi
+++ b/python/pysrc/longbridge/openapi.pyi
@@ -1047,7 +1047,7 @@ class SecurityDepth:
     Ask depth
     """
 
-    asks: List[Depth]
+    bids: List[Depth]
     """
     Bid depth
     """


### PR DESCRIPTION
There is a harmless typo in class SecurityDepth, here is a quick fix 