### PR TITLE
fix typo in openapi.pyi

### DIFF
--- a/python/pysrc/longbridge/openapi.pyi
+++ b/python/pysrc/longbridge/openapi.pyi
@@ -1431,7 +1431,7 @@ class TradingSessionInfo:
     End trading time
     """
 
-    trade_sessions: Type[TradeSession]
+    trade_session: Type[TradeSession]
     """
     Trading sessions
     """


### PR DESCRIPTION
There is a harmless typo in class SecurityDepth, here is a quick fix, to keep my PyCharm quiet😊